### PR TITLE
addresses github action CI error - engine not compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "react-dom": "18.2.0"
       },
       "engines": {
-        "node": "^18.12.1",
-        "npm": "^8.19.2"
+        "node": "^18.12.0",
+        "npm": "^8.19.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "^18.12.1",
-    "npm": "^8.19.2"
+    "node": "^18.12.0",
+    "npm": "^8.19.0"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Description

Our github deploy action [failed](https://github.com/tulsaschoolsdata/courses/actions/runs/3493310790) on the new .npmrc -> engine-strict=true. This relaxes the version requirements to match what the github action is using.