### PR TITLE
Jdb/only run prettier on pr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,5 @@
 name: Deploy Next.js site to Pages
 
-concurrency: production
 
 on:
   # Runs on pushes targeting the default branch

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,12 +1,7 @@
 name: Prettier Code Formatter
 
-concurrency: production
-
 on:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   prettier:


### PR DESCRIPTION
## Description

Because we don't push directly to main, we can have the prettier github action only run on pull requests.