### PR TITLE
Desktop View: UI Improvements

### DIFF
--- a/components/card.js
+++ b/components/card.js
@@ -58,7 +58,7 @@ export default function CourseCard({ course }) {
               horizontal: 'left',
             }}
           >
-            {name}
+            <Typography sx={{ p: 1 }}>{name}</Typography>
           </Popover>
         )}
         {department && (

--- a/components/card.js
+++ b/components/card.js
@@ -9,16 +9,11 @@ import Typography from '@mui/material/Typography'
 import { truncate } from 'lodash'
 
 export default function CourseCard({ course }) {
-  const {
-    department,
-    description,
-    name,
-    number
-  } = course
+  const { department, description, name, number } = course
 
   const [anchorEl, setAnchorEl] = useState(null)
 
-  const handlePopoverOpen = event => {
+  const handlePopoverOpen = (event) => {
     setAnchorEl(event.currentTarget)
   }
 
@@ -29,7 +24,14 @@ export default function CourseCard({ course }) {
   const isTruncatedTitle = name.length > 30
 
   return (
-    <Card sx={{ minHeight: 300, width: 250, display: 'flex', flexDirection: 'column' }}>
+    <Card
+      sx={{
+        minHeight: 300,
+        width: 250,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <CardContent sx={{ flexGrow: 1 }}>
         <Typography
           gutterBottom
@@ -43,7 +45,7 @@ export default function CourseCard({ course }) {
           <Popover
             sx={{
               pointerEvents: 'none',
-              width: '100%'
+              width: '100%',
             }}
             open={Boolean(anchorEl)}
             anchorEl={anchorEl}
@@ -61,15 +63,17 @@ export default function CourseCard({ course }) {
             <Typography sx={{ p: 1 }}>{name}</Typography>
           </Popover>
         )}
-        {department && (
-          <Chip label={department} sx={{ marginBottom: 1 }} />
-        )}
+        {department && <Chip label={department} sx={{ marginBottom: 1 }} />}
         <Typography>
-          {description ? truncate(description, {
-            length: 100,
-          }) : 'No description available.'}
+          {description
+            ? truncate(description, {
+                length: 100,
+              })
+            : 'No description available.'}
         </Typography>
-        <Link sx={{ position: 'fixed' }} href={`/course/${number}`}>Read More</Link>
+        <Link sx={{ position: 'fixed' }} href={`/course/${number}`}>
+          Read More
+        </Link>
       </CardContent>
     </Card>
   )

--- a/components/card.js
+++ b/components/card.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
-import CardMedia from '@mui/material/CardMedia'
 import Link from 'next/link'
+import Popover from '@mui/material/Popover'
 import PropTypes from 'prop-types'
 import Typography from '@mui/material/Typography'
 import { truncate } from 'lodash'
@@ -14,24 +14,57 @@ export default function CourseCard({ course }) {
     number
   } = course
 
+  const [anchorEl, setAnchorEl] = useState(null)
+
+  const handlePopoverOpen = event => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null)
+  }
+
+  const isTruncatedTitle = name.length > 30
+
   return (
-    <Card sx={{ height: 300, display: 'flex', flexDirection: 'column' }}>
-      <CardMedia
-        component="img"
-        image="https://source.unsplash.com/random?Education"
-        alt="random"
-        height={50}
-      />
+    <Card sx={{ minHeight: 300, width: 250, display: 'flex', flexDirection: 'column' }}>
       <CardContent sx={{ flexGrow: 1 }}>
-        <Typography gutterBottom variant="h5" component="h2">
-          {name}
+        <Typography
+          gutterBottom
+          variant="h6"
+          onMouseEnter={isTruncatedTitle ? handlePopoverOpen : null}
+          onMouseLeave={isTruncatedTitle ? handlePopoverClose : null}
+        >
+          {truncate(name, { length: 30 })}
         </Typography>
+        {isTruncatedTitle && (
+          <Popover
+            sx={{
+              pointerEvents: 'none',
+              width: '100%'
+            }}
+            open={Boolean(anchorEl)}
+            anchorEl={anchorEl}
+            onClose={handlePopoverClose}
+            disableRestoreFocus
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'left',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+          >
+            {name}
+          </Popover>
+        )}
         <Typography>
-          {truncate(description, {
+          {description ? truncate(description, {
             length: 100,
-          })}
+          }) : 'No description available.'}
         </Typography>
-        <Link href={`/course/${number}`}>Read More</Link>
+        <Link sx={{ position: 'fixed' }} href={`/course/${number}`}>Read More</Link>
       </CardContent>
     </Card>
   )

--- a/components/card.js
+++ b/components/card.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
+import Chip from '@mui/material/Chip'
 import Link from 'next/link'
 import Popover from '@mui/material/Popover'
 import PropTypes from 'prop-types'
@@ -9,6 +10,7 @@ import { truncate } from 'lodash'
 
 export default function CourseCard({ course }) {
   const {
+    department,
     description,
     name,
     number
@@ -58,6 +60,9 @@ export default function CourseCard({ course }) {
           >
             {name}
           </Popover>
+        )}
+        {department && (
+          <Chip label={department} sx={{ marginBottom: 1 }} />
         )}
         <Typography>
           {description ? truncate(description, {

--- a/components/layout.js
+++ b/components/layout.js
@@ -3,7 +3,6 @@ import AppBar from '@mui/material/AppBar'
 import { createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import Footer from '../components/footer'
-import Grid from '@mui/material/Grid'
 import PageContainer from './page-container'
 import SchoolIcon from '@mui/icons-material/School'
 import ThemeProvider from '@mui/material/styles/ThemeProvider'
@@ -17,7 +16,7 @@ export default function Layout({ children }) {
     <>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <AppBar position="fixed">
+        <AppBar sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
           <Toolbar>
             <SchoolIcon sx={{ mr: 2 }} />
             <Typography variant="h6" color="inherit" noWrap>

--- a/components/layout.js
+++ b/components/layout.js
@@ -17,7 +17,7 @@ export default function Layout({ children }) {
     <>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <AppBar position="relative">
+        <AppBar position="fixed">
           <Toolbar>
             <SchoolIcon sx={{ mr: 2 }} />
             <Typography variant="h6" color="inherit" noWrap>

--- a/components/page-container.js
+++ b/components/page-container.js
@@ -9,7 +9,7 @@ export default function PageContainer({ children }) {
           maxWidth="md"
           sx={{
             bgcolor: 'background.paper',
-            pt: 2,
+            pt: '6em',
             pb: 2
           }}
         >

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -49,7 +49,7 @@ export default function Filters({
   }, [filters.search])
 
   return (
-    <Stack spacing={1}>
+    <Stack spacing={1} sx={{ p: 2, paddingTop: '6em' }}>
       <Typography variant="">Filters</Typography>
       <TextField
         id="search"

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -18,7 +18,7 @@ export default function Filters({
   handleChange,
   schools,
 }) {
-  const [search, setSearch] = useState(filters.search)
+  const [search, setSearch] = useState('')
   const [timer, setTimer] = useState(null)
 
   const schoolName = (number) => {
@@ -41,11 +41,13 @@ export default function Filters({
   }
 
   useEffect(() => {
-    if (filters.search === '') {
+    if (filters.search) {
+      setSearch(filters.search)
+    } else {
       setSearch('')
     }
   }, [filters.search])
-  
+
   return (
     <Stack spacing={1}>
       <Typography variant="">Filters</Typography>

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -45,7 +45,7 @@ export default function Filters({
       setSearch('')
     }
   }, [filters.search])
-
+  
   return (
     <Stack spacing={1}>
       <Typography variant="">Filters</Typography>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import CourseCard from '../components/card'
 import data from './../courses.json'
+import Drawer from '@mui/material/Drawer';
 import Filters from '../lib/filters'
 import Fuse from 'fuse.js'
 import Grid from '@mui/material/Grid'
@@ -76,8 +77,19 @@ export default function Courses({
   }, [filters])
 
   return (
-    <Grid container spacing={2} direction="row">
-      <Grid item xs={12} sm={4}>
+    <Box>
+      <Drawer
+        sx={{
+          width: 240,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            boxSizing: 'border-box',
+            width: 240
+          },
+        }}
+        variant="permanent"
+        anchor="left"
+      >
         <Filters
           clearFilters={clearFilters}
           departments={departments}
@@ -85,8 +97,8 @@ export default function Courses({
           schools={schools}
           handleChange={handleChange}
         />
-      </Grid>
-      <Grid item xs={12} sm={8} ref={parent}>
+      </Drawer>
+      <Box>
         {filteredCourses.map((course) => (
           <Box
             key={course.number}
@@ -97,8 +109,8 @@ export default function Courses({
             <CourseCard course={course} />
           </Box>
         ))}
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
   )
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
 import CourseCard from '../components/card'
 import data from './../courses.json'
 import Filters from '../lib/filters'
@@ -87,15 +88,14 @@ export default function Courses({
       </Grid>
       <Grid item xs={12} sm={8} ref={parent}>
         {filteredCourses.map((course) => (
-          <Grid
-            item
+          <Box
             key={course.number}
             xs={12}
             sm={6}
-            sx={{ p: 2, display: 'inline-block' }}
+            sx={{ p: 1, display: 'inline-block' }}
           >
             <CourseCard course={course} />
-          </Grid>
+          </Box>
         ))}
       </Grid>
     </Grid>


### PR DESCRIPTION
## Description

- Added department to cards.
- Abbreviated long course names and added popover to see full name.
- Added a fixed Drawer component to house filters.
- Reverted AppBar to original position prop value ("fixed").
- Fixed card height to always show "Read More" link.
- Fixed error when hovering "Read More" Link element (wrong cursor icon appeared as the mouse event was being intercepted by parent element).
- Fixed an issue where a stored search filter value in localStorage was not appearing as the default search value on page reload.

⚠️ Shrinking the viewport or increasing the zoom over 100% will cause some overlap between the Filters/Cards.

## Screenshot

**Fixed navbar/filters:**
<img width="1176" alt="Screenshot 2022-11-28 at 2 00 19 PM" src="https://user-images.githubusercontent.com/33558504/204370131-e302b358-26ed-4da3-b4ec-9c71099fea85.png">

**Added department to cards:**
<img width="836" alt="Screenshot 2022-11-28 at 2 09 55 PM" src="https://user-images.githubusercontent.com/33558504/204371468-3c91a5a5-584b-4797-89e6-fbc482b044fc.png">

**Added popover for long course titles:**
<img width="390" alt="Screenshot 2022-11-28 at 2 10 49 PM" src="https://user-images.githubusercontent.com/33558504/204371545-87300ddb-9344-4408-9fc5-1a04174c100d.png">