### PR TITLE
tm/update-filters

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -172,7 +172,7 @@ export default function Search() {
           >
             <Grid container component={ListSubheader} justifyContent="flex-end">
               <Button
-                variant='outlined'
+                variant="outlined"
                 onClick={() => {
                   handleChange('schools', [])
                 }}
@@ -181,7 +181,7 @@ export default function Search() {
                 Clear
               </Button>
               <Button
-                variant='contained'
+                variant="contained"
                 onClick={() => {
                   setShowSchoolSelector(false)
                 }}
@@ -214,7 +214,7 @@ export default function Search() {
         >
           <Grid container component={ListSubheader} justifyContent="flex-end">
             <Button
-              variant='outlined'
+              variant="outlined"
               onClick={() => {
                 handleChange('creditType', '')
               }}
@@ -223,7 +223,7 @@ export default function Search() {
               Clear
             </Button>
             <Button
-              variant='contained'
+              variant="contained"
               onClick={() => {
                 setShowCreditTypeSelector(false)
               }}


### PR DESCRIPTION
## Description

- manage open/close state of Search selectors
- add clear/close buttons within selectors

## Screenshot

![manage-open-state-of-selectors](https://user-images.githubusercontent.com/33558504/217039995-330ec943-7e6c-46c0-882e-5b3890121477.gif)

## Steps to Verify

Follow actions in above GIF.

**_Introduces a 🐛:_** When the Credit Type filter has no value selected (`''`), the top option has an active state. 