### PR TITLE
change: the "current" course catalog name is now "Site based"  🤷

### DIFF
--- a/data/generators/catalog
+++ b/data/generators/catalog
@@ -71,7 +71,8 @@ schools = fetch_all(path: 'schools.all', matching: { 'schools.state_excludefromr
           end
 
 courses = fetch_all(path: 'course_catalog',
-                    body: { course_number_matcher: '^[0-9]+$',
+                    body: { catalog_name_matcher: '^Site based$',
+                            course_number_matcher: '^[0-9]+$',
                             course_name_exclusions: '\b(attendance|homeroom|self|monitoring)\b' })
           .to_h do |course|
             [


### PR DESCRIPTION
# change: the "current" course catalog name is now "Site based"  🤷

## Description

It's been decided the "current" course catalogs are no longer to be named "<sy> - <sy>" and will instead be "Site based". This simply sets the catalog name regex passed to the "course_catalog" PowerQuery.

I'm told the data change will be made on the PowerSchool side sometime today, so this may yield an empty course catalog *right now*.

## Steps to Verify

**Once the PowerSchool data change is made**, triggering the catalog generator should still yield a sensible (i.e. non-empty) dataset.
