### PR TITLE
upgrade package json engines to match the upgraded ubuntu-latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "^18.12.0",
-    "npm": "^8.19.0"
+    "node": "^18.14.0",
+    "npm": "^9.3.1"
   },
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",


### PR DESCRIPTION
## Description

Our github deploy workflow is using ubuntu latest and npm jumped a major version and node a minor.

``` 
npm ERR! notsup Required: {"node":"^18.12.0","npm":"^8.19.0"}
npm ERR! notsup Actual:   {"npm":"9.3.1","node":"v18.14.0"}
```