### PR TITLE
version pin the runs-on image to ubuntu-22.04 for GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       POWERSCHOOL_BASE_URI: ${{ secrets.POWERSCHOOL_BASE_URI }}
       POWERSCHOOL_CLIENT_ID: ${{ secrets.POWERSCHOOL_CLIENT_ID }}
@@ -97,7 +97,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prettier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description

This version pins the runs-on images to ubuntu-22.04 for all github actions. Ubuntu-latest was recently upgraded precipitating the need for the change.

## Steps to verify

Test suite GH action should run and the deploy action should build the site without complaining about our node and npm versions.